### PR TITLE
Fix MismatchingStateError when state is a bytes object

### DIFF
--- a/flask_discord/client.py
+++ b/flask_discord/client.py
@@ -55,7 +55,11 @@ class DiscordOAuth2Session(_http.DiscordOAuth2HttpClient):
 
     @staticmethod
     def __get_state():
-        return session.get("DISCORD_OAUTH2_STATE", str())
+        _state = session.get("DISCORD_OAUTH2_STATE", str())
+        # Because we use JWT, sometimes the state can be stored as a bytes object, so we have to decode it into a string for Oauth2 to parse it correctly
+        if isinstance(_state, bytes):
+            _state = _state.decode()
+        return _state
 
     def create_session(
             self, scope: list = None, *, data: dict = None, prompt: bool = True,


### PR DESCRIPTION
Since we use JWT to store the state/session it can sometimes be stored as a bytes object instead of a string. The Oauth2 lib expects state to be a string. This detects if state is a bytes object and if so, decodes it to a string to pass to oauth2.

I came across this issue while testing a real deployment.